### PR TITLE
Prevent stripping of parenthesis on where clauses

### DIFF
--- a/rest_framework_mvt/managers.py
+++ b/rest_framework_mvt/managers.py
@@ -106,7 +106,7 @@ class MVTManager(models.Manager):
             sql, params = self.filter(**filters).query.sql_with_params()
         except FieldError as error:
             raise ValidationError(str(error))
-        extra_wheres = " AND " + sql.split("WHERE")[1].strip()[1:-1] if params else ""
+        extra_wheres = " AND " + sql.split("WHERE")[1].strip() if params else ""
         where_clause = (
             f"ST_Intersects({table}.{self.geo_col}, "
             f"ST_SetSRID(ST_GeomFromText(%s), 4326)){extra_wheres}"


### PR DESCRIPTION
This pull request prevents stripping of parenthesis on where clauses.  The bug was identified in issue https://github.com/corteva/djangorestframework-mvt/issues/4.  The changes were also tested locally in a project using djangorestframework-mvt.

Checklist:
 - [x] Closes issue #4
 - [x] Tests added