### PR TITLE
Fix Error With GenericRelation

### DIFF
--- a/rest_framework_mvt/managers.py
+++ b/rest_framework_mvt/managers.py
@@ -57,7 +57,7 @@ class MVTManager(models.Manager):
         for field in self.model._meta.get_fields():
             if hasattr(field, "get_attname_column"):
                 column_name = field.get_attname_column()[1]
-                if column_name != self.geo_col:
+                if column_name and column_name != self.geo_col:
                     columns.append(column_name)
         return columns
 

--- a/test/unit/test_mvt_manager.py
+++ b/test/unit/test_mvt_manager.py
@@ -36,6 +36,9 @@ def mvt_manager_no_col():
             get_attname_column=MagicMock(return_value=("jazzy_geo", "jazzy_geo"))
         ),
         MagicMock(get_attname_column=MagicMock(return_value=("city", "city"))),
+        MagicMock(
+            get_attname_column=MagicMock(return_value=("generic_relation", None))
+        ),
     ]
     meta.get_fields.return_value = fields
     mvt_manager_no_col.model = MagicMock(_meta=meta)
@@ -99,6 +102,7 @@ def test_mvt_manager_build_query__no_geo_col(get_conn, only, mvt_manager_no_col)
 
     assert expected_query == query
     assert expected_parameters == parameters
+    only.assert_called_once_with("other_column", "jazzy_geo", "city")
 
 
 @patch("rest_framework_mvt.managers.MVTManager.filter")


### PR DESCRIPTION
I experienced an error when adding the MVTManager to models with [GenericRelations](https://docs.djangoproject.com/en/3.1/ref/contrib/contenttypes/#django.contrib.contenttypes.fields.GenericRelation). This is because the second value in the return from `field.get_attname_column()` was `None`. For example: `('comments', None)`.

 - [x] Tests added
