### PR TITLE
Customizable model queryset

### DIFF
--- a/rest_framework_mvt/managers.py
+++ b/rest_framework_mvt/managers.py
@@ -101,6 +101,9 @@ class MVTManager(models.Manager):
         )
         return where_clause, list(params)
 
+    def get_model(self):
+        return self
+
     def _create_select_statement(self):
         """
         Create a SELECT statement that only includes columns defined on the
@@ -112,7 +115,7 @@ class MVTManager(models.Manager):
             str:
             A string representing a parameterized SQL query SELECT statement.
         """
-        sql, _ = self.defer(self.geo_col).query.sql_with_params()
+        sql, _ = self.get_model().defer(self.geo_col).query.sql_with_params()
         select_sql = sql.split("FROM")[0].lstrip("SELECT ").strip() + ","
         return select_sql
 

--- a/rest_framework_mvt/managers.py
+++ b/rest_framework_mvt/managers.py
@@ -49,18 +49,6 @@ class MVTManager(models.Manager):
             mvt = cursor.fetchall()[-1][-1]  # should always return one tile on success
         return mvt
 
-    def _get_non_geom_columns(self):
-        """
-        Retrieves all table columns that are NOT the defined geometry column
-        """
-        columns = []
-        for field in self.model._meta.get_fields():
-            if hasattr(field, "get_attname_column"):
-                column_name = field.get_attname_column()[1]
-                if column_name and column_name != self.geo_col:
-                    columns.append(column_name)
-        return columns
-
     def _build_query(self, filters={}):
         """
         Args:
@@ -124,8 +112,7 @@ class MVTManager(models.Manager):
             str:
             A string representing a parameterized SQL query SELECT statement.
         """
-        columns = self._get_non_geom_columns()
-        sql, _ = self.only(*columns).query.sql_with_params()
+        sql, _ = self.defer(self.geo_col).query.sql_with_params()
         select_sql = sql.split("FROM")[0].lstrip("SELECT ").strip() + ","
         return select_sql
 

--- a/rest_framework_mvt/managers.py
+++ b/rest_framework_mvt/managers.py
@@ -108,7 +108,7 @@ class MVTManager(models.Manager):
             raise ValidationError(str(error)) from error
         extra_wheres = " AND " + sql.split("WHERE")[1].strip() if params else ""
         where_clause = (
-            f"ST_Intersects({table}.{self.geo_col}, "
+            f"ST_Intersects(ST_Transform({table}.{self.geo_col}, 4326), "
             f"ST_SetSRID(ST_GeomFromText(%s), 4326)){extra_wheres}"
         )
         return where_clause, list(params)


### PR DESCRIPTION
Closes #17 

Sorry - two things are happening here:
1. I refactored `_get_non_geom_columns(self):` function into much more simpler (and equal) `self.defer("geom")` query
2. Added (almost empty) function `get_model(self)` which can be customized by user, for example (given a model with field "name"):
```
class MVTManagerPlus(MVTManager):
    def get_model(self):
        return self.annotate(name2=models.F("name"))
```
This works for me. By this, also joins and more complex annotations would be possible. Filters using annotations should also work out of the box...
