### PR TITLE
support isnull filter

### DIFF
--- a/rest_framework_mvt/managers.py
+++ b/rest_framework_mvt/managers.py
@@ -106,7 +106,7 @@ class MVTManager(models.Manager):
             sql, params = self.filter(**filters).query.sql_with_params()
         except FieldError as error:
             raise ValidationError(str(error)) from error
-        extra_wheres = " AND " + sql.split("WHERE")[1].strip() if params else ""
+        extra_wheres = " AND " + sql.split("WHERE")[1].strip() if filters else ""
         where_clause = (
             f"ST_Intersects(ST_Transform({table}.{self.geo_col}, 4326), "
             f"ST_SetSRID(ST_GeomFromText(%s), 4326)){extra_wheres}"

--- a/rest_framework_mvt/views.py
+++ b/rest_framework_mvt/views.py
@@ -6,6 +6,25 @@ from rest_framework_mvt.renderers import BinaryRenderer
 from rest_framework_mvt.schemas import MVT_SCHEMA
 
 
+def is_bool_or_null(value: str):
+    if value in ("True", "true", "y", "yes"):
+        return True
+    if value in ("False", "false", "n", "no"):
+        return False
+    if value in ("None", "null", "NULL", ""):
+        return None
+    return value
+
+
+def autocast(value: str):
+    for fn in (is_bool_or_null, int, float):
+        try:
+            return fn(value)
+        except ValueError:
+            pass
+    return value
+
+
 class BaseMVTView(APIView):
     """
     Base view for serving a model as a Mapbox Vector Tile given X/Y/Z tile constraints.
@@ -25,6 +44,10 @@ class BaseMVTView(APIView):
             :py:class:`rest_framework.response.Response`:  Standard DRF response object
         """
         params = request.GET.dict()
+
+        for key, value in params.items():
+            params[key] = autocast(value)
+
         if params.pop("tile", None) is not None:
             try:
                 limit, offset = self._validate_paginate(


### PR DESCRIPTION
Add support for filter modifiers that have a boolean argument (example: __isnull=True).
Add support for filters with null as argument (example: parent_id=None)

